### PR TITLE
feat: add exchangeCode options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.0.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.1.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/auth-context.tsx
+++ b/src/auth-context.tsx
@@ -6,7 +6,11 @@ import { AuthState, initialAuthState } from './auth-state';
 export interface AuthContextInterface extends AuthState {
   getAccessTokenSilently: () => Promise<string>;
 
-  loginWithRedirect: (options?: AuthRequestPromptOptions) => Promise<void>;
+  loginWithRedirect: (
+    options?: AuthRequestPromptOptions & {
+      [key: string]: any;
+    }
+  ) => Promise<void>;
 
   logout: () => Promise<void>;
 }

--- a/src/auth-provider.tsx
+++ b/src/auth-provider.tsx
@@ -82,14 +82,54 @@ export function AuthProvider(props: AuthProviderProps) {
   );
 
   const loginWithRedirect = useCallback(
-    async (opts?: Record<string, string>, promptOpts?: AuthRequestPromptOptions) => {
-      const _opts = opts ?? {};
+    async (
+      opts?: AuthRequestPromptOptions & {
+        [key: string]: any;
+      }
+    ) => {
       setAuthState(state => ({
         isLoading: true,
         isAuthenticated: state.isAuthenticated,
       }));
 
-      const result = await promptAsync(promptOpts);
+      const {
+        toolbarColor,
+        browserPackage,
+        enableBarCollapsing,
+        secondaryToolbarColor,
+        showTitle,
+        enableDefaultShareMenuItem,
+        showInRecents,
+        createTask,
+        controlsColor,
+        dismissButtonStyle,
+        readerMode,
+        windowName,
+        windowFeatures,
+        url,
+        useProxy,
+        proxyOptions,
+        ...rest
+      } = opts ?? {};
+
+      const result = await promptAsync({
+        toolbarColor,
+        browserPackage,
+        enableBarCollapsing,
+        secondaryToolbarColor,
+        showTitle,
+        enableDefaultShareMenuItem,
+        showInRecents,
+        createTask,
+        controlsColor,
+        dismissButtonStyle,
+        readerMode,
+        windowName,
+        windowFeatures,
+        url,
+        useProxy,
+        proxyOptions,
+      });
 
       if (result.type === 'success') {
         const { accessToken, idToken, refreshToken } = await exchangeCodeAsync(
@@ -100,7 +140,7 @@ export function AuthProvider(props: AuthProviderProps) {
             extraParams: request?.codeVerifier
               ? { code_verifier: request?.codeVerifier }
               : {},
-            ..._opts,
+            ...rest,
           },
           { tokenEndpoint: `https://${domain}/oauth/token` }
         );

--- a/src/auth-provider.tsx
+++ b/src/auth-provider.tsx
@@ -82,13 +82,14 @@ export function AuthProvider(props: AuthProviderProps) {
   );
 
   const loginWithRedirect = useCallback(
-    async (options?: AuthRequestPromptOptions) => {
+    async (opts?: Record<string, string>, promptOpts?: AuthRequestPromptOptions) => {
+      const _opts = opts ?? {};
       setAuthState(state => ({
         isLoading: true,
         isAuthenticated: state.isAuthenticated,
       }));
 
-      const result = await promptAsync(options);
+      const result = await promptAsync(promptOpts);
 
       if (result.type === 'success') {
         const { accessToken, idToken, refreshToken } = await exchangeCodeAsync(
@@ -99,6 +100,7 @@ export function AuthProvider(props: AuthProviderProps) {
             extraParams: request?.codeVerifier
               ? { code_verifier: request?.codeVerifier }
               : {},
+            ..._opts,
           },
           { tokenEndpoint: `https://${domain}/oauth/token` }
         );


### PR DESCRIPTION
## Summary
added `opts` and `prompOpts` into `loginWithRedirect ` function because in some cases we need to pass additional information, for example

```ts
await loginWithRedirect({warehouseId: 'warehouse-1'});
```

with this PR I also bump the `major` version because it will break current version implementation