### PR TITLE
fix: refresh token logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/auth-provider.tsx
+++ b/src/auth-provider.tsx
@@ -128,9 +128,11 @@ export function AuthProvider(props: AuthProviderProps) {
 
   const getAccessTokenSilently = useCallback(async () => {
     if (accessToken) {
-      const { iat, exp } = jwtDecode<any>(accessToken);
-
-      if (new Date((iat + exp) * 1000) > new Date()) {
+      const { exp } = jwtDecode<any>(accessToken);
+      
+      const buffer = 60000 * 2;
+      
+      if ((new Date().getTime() - buffer) > new Date(exp * 1000).getTime()) {
         return accessToken;
       }
     }


### PR DESCRIPTION
idk why the previous logic using `iat` to determine timing to refresh the token, I adjust the logic by using buffer 2 min

if `now - 2 min > exp` then the token still valid, else  `refresh token`